### PR TITLE
2.80 beta

### DIFF
--- a/scripts/addons/cam/collision.py
+++ b/scripts/addons/cam/collision.py
@@ -184,7 +184,7 @@ def prepareBulletCollision(o):
         collisionob.rigid_body.collision_margin = o.skin * BULLET_SCALE
         bpy.ops.transform.resize(value=(BULLET_SCALE, BULLET_SCALE, BULLET_SCALE),
                                  constraint_axis=(False, False, False), orient_type='GLOBAL', mirror=False,
-                                 proportional='DISABLED', proportional_edit_falloff='SMOOTH', proportional_size=1,
+                                 use_proportional_edit=False, proportional_edit_falloff='SMOOTH', proportional_size=1,
                                  snap=False, snap_target='CLOSEST', snap_point=(0, 0, 0), snap_align=False,
                                  snap_normal=(0, 0, 0), texture_space=False, release_confirm=False)
         collisionob.location = collisionob.location * BULLET_SCALE

--- a/scripts/addons/cam/collision.py
+++ b/scripts/addons/cam/collision.py
@@ -199,7 +199,7 @@ def prepareBulletCollision(o):
             activate(ob)
             bpy.ops.transform.resize(value=(BULLET_SCALE, BULLET_SCALE, BULLET_SCALE),
                                      constraint_axis=(False, False, False), orient_type='GLOBAL',
-                                     mirror=False, proportional='DISABLED', proportional_edit_falloff='SMOOTH',
+                                     mirror=False, use_proportional_edit=False, proportional_edit_falloff='SMOOTH',
                                      proportional_size=1, snap=False, snap_target='CLOSEST', snap_point=(0, 0, 0),
                                      snap_align=False, snap_normal=(0, 0, 0), texture_space=False,
                                      release_confirm=False)
@@ -225,7 +225,7 @@ def cleanupBulletCollision(o):
             activate(ob)
             bpy.ops.transform.resize(value=(1.0 / BULLET_SCALE, 1.0 / BULLET_SCALE, 1.0 / BULLET_SCALE),
                                      constraint_axis=(False, False, False), orient_type='GLOBAL',
-                                     mirror=False, proportional='DISABLED', proportional_edit_falloff='SMOOTH',
+                                     mirror=False, use_proportional_edit=False, proportional_edit_falloff='SMOOTH',
                                      proportional_size=1, snap=False, snap_target='CLOSEST', snap_point=(0, 0, 0),
                                      snap_align=False, snap_normal=(0, 0, 0), texture_space=False,
                                      release_confirm=False)

--- a/scripts/addons/cam/opencamlib/opencamlib.py
+++ b/scripts/addons/cam/opencamlib/opencamlib.py
@@ -92,7 +92,7 @@ def exportModelsToSTL(operation):
         file_name = os.path.join(tempfile.gettempdir(), "model{0}.stl".format(str(file_number)))
         bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
         bpy.ops.transform.resize(value=(OCL_SCALE, OCL_SCALE, OCL_SCALE), constraint_axis=(False, False, False),
-                                 orient_type='GLOBAL', mirror=False, proportional='DISABLED',
+                                 orient_type='GLOBAL', mirror=False, use_proportional_edit=False,
                                  proportional_edit_falloff='SMOOTH', proportional_size=1, snap=False,
                                  snap_target='CLOSEST', snap_point=(0, 0, 0), snap_align=False, snap_normal=(0, 0, 0),
                                  texture_space=False, release_confirm=False)

--- a/scripts/addons/cam/simple.py
+++ b/scripts/addons/cam/simple.py
@@ -109,7 +109,7 @@ def dupliob(o, pos):
     bpy.ops.object.duplicate()
     s = 1.0 / BULLET_SCALE
     bpy.ops.transform.resize(value=(s, s, s), constraint_axis=(False, False, False), orient_type='GLOBAL',
-                             mirror=False, proportional='DISABLED', proportional_edit_falloff='SMOOTH',
+                             mirror=False, use_proportional_edit=False, proportional_edit_falloff='SMOOTH',
                              proportional_size=1)
     o = bpy.context.active_object
     bpy.ops.rigidbody.object_remove()

--- a/scripts/addons/cam/testing.py
+++ b/scripts/addons/cam/testing.py
@@ -30,11 +30,11 @@ def addTestCurve(loc):
     bpy.ops.object.editmode_toggle()
     bpy.ops.curve.duplicate()
     bpy.ops.transform.resize(value=(0.5, 0.5, 0.5), constraint_axis=(False, False, False),
-                             orient_type='GLOBAL', mirror=False, proportional='DISABLED',
+                             orient_type='GLOBAL', mirror=False, use_proportional_edit=False,
                              proportional_edit_falloff='SMOOTH', proportional_size=1)
     bpy.ops.curve.duplicate()
     bpy.ops.transform.resize(value=(0.5, 0.5, 0.5), constraint_axis=(False, False, False),
-                             orient_type='GLOBAL', mirror=False, proportional='DISABLED',
+                             orient_type='GLOBAL', mirror=False, use_proportional_edit=False,
                              proportional_edit_falloff='SMOOTH', proportional_size=1)
     bpy.ops.object.editmode_toggle()
 

--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -2062,7 +2062,7 @@ def addBridge(x, y, rot, sizex, sizey):
 
     bpy.ops.object.editmode_toggle()
     bpy.ops.transform.translate(value=(0, sizey / 2, 0), constraint_axis=(False, True, False),
-                                orient_type='GLOBAL', mirror=False, proportional='DISABLED',
+                                orient_type='GLOBAL', mirror=False, use_proportional_edit=False,
                                 proportional_edit_falloff='SMOOTH', proportional_size=1)
     bpy.ops.object.editmode_toggle()
     bpy.ops.object.convert(target='CURVE')
@@ -2647,7 +2647,7 @@ def strategy_drill(o):
                                       TRANSFORM_OT_translate={"value": (0, 0, 0),
                                                               "constraint_axis": (False, False, False),
                                                               "orient_type": 'GLOBAL', "mirror": False,
-                                                              "proportional": 'DISABLED',
+                                                              "use_proportional_edit": False,
                                                               "proportional_edit_falloff": 'SMOOTH',
                                                               "proportional_size": 1, "snap": False,
                                                               "snap_target": 'CLOSEST', "snap_point": (0, 0, 0),


### PR DESCRIPTION
Hi!
BlenderCAM stopped working with most recent Blender 2.8 versions due to API changes in bpy.ops.transform.resize. Please let me know if my fix is correct - for me it seems to work well.
Drill operation has still to be updated.
(Last pull request I created was in wrong direction, I hope this one works as intended)